### PR TITLE
Add missing target include path for lua

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ if (UNIX)
 	target_link_libraries(lua m ${CMAKE_DL_LIBS})
 endif()
 
+target_include_directories(lua INTERFACE "${CMAKE_CURRENT_LIST_DIR}/src")
 
 
 # If system-wide Lua is not available, build a local one:


### PR DESCRIPTION
From the `fix-cmake` branch