### PR TITLE
Backwards compatibility STD lib introductions

### DIFF
--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -595,6 +595,13 @@ static int luaB_yield (lua_State *L) {
 }
 
 
+static int luaB_yieldable (lua_State *L) {
+  lua_State *co = getoptco(L);
+  lua_pushboolean(L, lua_isyieldable(co));
+  return 1;
+}
+
+
 static int luaB_corunning (lua_State *L) {
   if (lua_pushthread(L))
     lua_pushnil(L);  /* main thread is not a coroutine */
@@ -609,6 +616,7 @@ static const luaL_Reg co_funcs[] = {
   {"status", luaB_costatus},
   {"wrap", luaB_cowrap},
   {"yield", luaB_yield},
+  {"isyieldable", luaB_yieldable},
   {NULL, NULL}
 };
 

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -170,7 +170,7 @@ static int luaB_rawlen (lua_State *L) {
   int t = lua_type(L, 1);
   luaL_argexpected(L, t == LUA_TTABLE || t == LUA_TSTRING, 1,
                       "table or string");
-  lua_pushinteger(L, l_castU2S(lua_rawlen(L, 1)));
+  lua_pushinteger(L, lua_objlen(L, 1));
   return 1;
 }
 

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -166,6 +166,15 @@ static int luaB_rawequal (lua_State *L) {
 }
 
 
+static int luaB_rawlen (lua_State *L) {
+  int t = lua_type(L, 1);
+  luaL_argexpected(L, t == LUA_TTABLE || t == LUA_TSTRING, 1,
+                      "table or string");
+  lua_pushinteger(L, l_castU2S(lua_rawlen(L, 1)));
+  return 1;
+}
+
+
 static int luaB_rawget (lua_State *L) {
   luaL_checktype(L, 1, LUA_TTABLE);
   luaL_checkany(L, 2);
@@ -459,6 +468,7 @@ static const luaL_Reg base_funcs[] = {
   {"pcall", luaB_pcall},
   {"print", luaB_print},
   {"rawequal", luaB_rawequal},
+  {"rawlen", luaB_rawlen},
   {"rawget", luaB_rawget},
   {"rawset", luaB_rawset},
   {"select", luaB_select},

--- a/src/lbaselib.cpp
+++ b/src/lbaselib.cpp
@@ -393,9 +393,10 @@ static int luaB_pcall (lua_State *L) {
 static int luaB_xpcall (lua_State *L) {
   int status;
   luaL_checkany(L, 2);
-  lua_settop(L, 2);
-  lua_insert(L, 1);  /* put error function under function to be called */
-  status = lua_pcall(L, 0, LUA_MULTRET, 1);
+  lua_pushvalue(L, 1);  /* exchange function... */
+  lua_copy(L, 2, 1);  /* ...and error handler */
+  lua_replace(L, 2);  /* put error function under function to be called */
+  status = lua_pcall(L, lua_gettop(L) - 2, LUA_MULTRET, 1);
   lua_pushboolean(L, (status == 0));
   lua_replace(L, 1);
   return lua_gettop(L);  /* return status + all results */

--- a/src/ldo.cpp
+++ b/src/ldo.cpp
@@ -440,6 +440,11 @@ LUA_API int lua_resume (lua_State *L, int nargs) {
 }
 
 
+LUA_API int lua_isyieldable (lua_State *L) {
+  return yieldable(L);
+}
+
+
 LUA_API int lua_yield (lua_State *L, int nresults) {
   luai_userstateyield(L, nresults);
   lua_lock(L);

--- a/src/ldo.cpp
+++ b/src/ldo.cpp
@@ -441,7 +441,7 @@ LUA_API int lua_resume (lua_State *L, int nargs) {
 
 
 LUA_API int lua_isyieldable (lua_State *L) {
-  return yieldable(L);
+  return !(L->nCcalls > L->baseCcalls || G(L)->mainthread == L);
 }
 
 

--- a/src/llimits.h
+++ b/src/llimits.h
@@ -78,6 +78,7 @@ typedef LUAI_UACNUMBER l_uacNumber;
 #define cast_byte(i)	cast(lu_byte, (i))
 #define cast_num(i)	cast(lua_Number, (i))
 #define cast_int(i)	cast(int, (i))
+#define cast_uint(i)    cast(unsigned int, (i))
 
 
 

--- a/src/lmathlib.cpp
+++ b/src/lmathlib.cpp
@@ -112,7 +112,16 @@ static int math_pow (lua_State *L) {
 }
 
 static int math_log (lua_State *L) {
-  lua_pushnumber(L, log(luaL_checknumber(L, 1)));
+  lua_Number x = luaL_checknumber(L, 1);
+  lua_Number res;
+  if (lua_isnoneornil(L, 2))
+    res = l_mathop(log)(x);
+  else {
+    lua_Number base = luaL_checknumber(L, 2);
+    if (base == (lua_Number)10.0) res = l_mathop(log10)(x);
+    else res = l_mathop(log)(x)/l_mathop(log)(base);
+  }
+  lua_pushnumber(L, res);
   return 1;
 }
 

--- a/src/lstrlib.cpp
+++ b/src/lstrlib.cpp
@@ -253,6 +253,7 @@ static int match_class (int c, int cl) {
     case 'a' : res = isalpha(c); break;
     case 'c' : res = iscntrl(c); break;
     case 'd' : res = isdigit(c); break;
+    case 'g' : res = isgraph(c); break;
     case 'l' : res = islower(c); break;
     case 'p' : res = ispunct(c); break;
     case 's' : res = isspace(c); break;

--- a/src/lstrlib.cpp
+++ b/src/lstrlib.cpp
@@ -90,15 +90,39 @@ static int str_upper (lua_State *L) {
   return 1;
 }
 
+
 static int str_rep (lua_State *L) {
-  size_t l;
-  luaL_Buffer b;
+  size_t l, lsep;
   const char *s = luaL_checklstring(L, 1, &l);
   int n = luaL_checkint(L, 2);
-  luaL_buffinit(L, &b);
-  while (n-- > 0)
-    luaL_addlstring(&b, s, l);
-  luaL_pushresult(&b);
+  const char *sep = luaL_optlstring(L, 3, "", &lsep);
+  if (n <= 0) lua_pushliteral(L, "");
+  else if (l + lsep < l || l + lsep >= MAX_SIZET / n)  /* may overflow? */
+    return luaL_error(L, "resulting string too large");
+  else {
+    size_t totallen = n * l + (n - 1) * lsep;
+    luaL_Buffer b;
+    #if USE_FAST_BUFFER
+      char *p = luaL_buffinitsize(L, &b, totallen); // Fast buffer upgrade is available
+      while (n-- > 1) {  /* first n-1 copies (followed by separator) */
+        memcpy(p, s, l * sizeof(char)); p += l;
+        if (lsep > 0) {  /* avoid empty 'memcpy' (may be expensive) */
+          memcpy(p, sep, lsep * sizeof(char)); p += lsep;
+        }
+      }
+      memcpy(p, s, l * sizeof(char));  /* last copy (not followed by separator) */
+    #else
+      luaL_buffinit(L, &b); // Fast buffer upgrade is not available
+      while (n-- > 1) {  /* first n-1 copies (followed by separator) */
+        luaL_addlstring(&b, s, l);
+        if (lsep > 0) {
+          luaL_addlstring(&b, s, lsep);
+        }
+      }
+      luaL_addlstring(&b, s, l);
+    #endif
+    luaL_pushresultsize(&b, totallen);
+  }
   return 1;
 }
 

--- a/src/lstrlib.cpp
+++ b/src/lstrlib.cpp
@@ -598,8 +598,9 @@ static int gmatch_aux (lua_State *L) {
 static int gmatch (lua_State *L) {
   luaL_checkstring(L, 1);
   luaL_checkstring(L, 2);
+  lua_Integer init = luaL_optinteger(L, 3, 0);
   lua_settop(L, 2);
-  lua_pushinteger(L, 0);
+  lua_pushinteger(L, init);
   lua_pushcclosure(L, gmatch_aux, 3);
   return 1;
 }

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -220,7 +220,7 @@ static int tpack (lua_State *L) {
   lua_createtable(L, n, 1);  /* create result table */
   lua_insert(L, 1);  /* put it at index 1 */
   for (i = n; i >= 1; i--)  /* assign elements */
-    lua_seti(L, 1, i);
+    lua_rawseti(L, 1, i);
   lua_pushinteger(L, n);
   lua_setfield(L, 1, "n");  /* t.n = number of elements */
   return 1;  /* return table */

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -161,6 +161,44 @@ static int tconcat (lua_State *L) {
 }
 
 
+/*
+** {======================================================
+** Pack/unpack
+** =======================================================
+*/
+
+static int tpack (lua_State *L) {
+  int i;
+  int n = lua_gettop(L);  /* number of elements to pack */
+  lua_createtable(L, n, 1);  /* create result table */
+  lua_insert(L, 1);  /* put it at index 1 */
+  for (i = n; i >= 1; i--)  /* assign elements */
+    lua_seti(L, 1, i);
+  lua_pushinteger(L, n);
+  lua_setfield(L, 1, "n");  /* t.n = number of elements */
+  return 1;  /* return table */
+}
+
+
+static int tunpack (lua_State *L) {
+  lua_Unsigned n;
+  lua_Integer i = luaL_optinteger(L, 2, 1);
+  lua_Integer e = luaL_opt(L, luaL_checkinteger, 3, luaL_len(L, 1));
+  if (i > e) return 0;  /* empty range */
+  n = l_castS2U(e) - l_castS2U(i);  /* number of elements minus 1 */
+  if (l_unlikely(n >= (unsigned int)INT_MAX  ||
+                 !lua_checkstack(L, (int)(++n))))
+    return luaL_error(L, "too many results to unpack");
+  for (; i < e; i++) {  /* push arg[i..e - 1] (to avoid overflows) */
+    lua_geti(L, 1, i);
+  }
+  lua_geti(L, 1, e);  /* push last element */
+  return (int)n;
+}
+
+/* }====================================================== */
+
+
 
 /*
 ** {======================================================

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -87,6 +87,16 @@ static int setn (lua_State *L) {
 }
 
 
+static int tcreate (lua_State *L) {
+  lua_Unsigned sizeseq = (lua_Unsigned)luaL_checkinteger(L, 1);
+  lua_Unsigned sizerest = (lua_Unsigned)luaL_optinteger(L, 2, 0);
+  luaL_argcheck(L, sizeseq <= cast_uint(INT_MAX), 1, "out of range");
+  luaL_argcheck(L, sizerest <= cast_uint(INT_MAX), 2, "out of range");
+  lua_createtable(L, cast_int(sizeseq), cast_int(sizerest));
+  return 1;
+}
+
+
 static int tinsert (lua_State *L) {
   int e = aux_getn(L, 1) + 1;  /* first empty element */
   int pos;  /* where to insert new element */
@@ -138,6 +148,43 @@ static void addfield (lua_State *L, luaL_Buffer *b, int i) {
     luaL_error(L, "invalid value (%s) at index %d in table for "
                   LUA_QL("concat"), luaL_typename(L, -1), i);
     luaL_addvalue(b);
+}
+
+/*
+** Copy elements (1[f], ..., 1[e]) into (tt[t], tt[t+1], ...). Whenever
+** possible, copy in increasing order, which is better for rehashing.
+** "possible" means destination after original range, or smaller
+** than origin, or copying to another table.
+*/
+static int tmove (lua_State *L) {
+  lua_Integer f = luaL_checkinteger(L, 2);
+  lua_Integer e = luaL_checkinteger(L, 3);
+  lua_Integer t = luaL_checkinteger(L, 4);
+  int tt = !lua_isnoneornil(L, 5) ? 5 : 1;  /* destination table */
+  checktab(L, 1, TAB_R);
+  checktab(L, tt, TAB_W);
+  if (e >= f) {  /* otherwise, nothing to move */
+    lua_Integer n, i;
+    luaL_argcheck(L, f > 0 || e < LUA_MAXINTEGER + f, 3,
+                  "too many elements to move");
+    n = e - f + 1;  /* number of elements to move */
+    luaL_argcheck(L, t <= LUA_MAXINTEGER - n + 1, 4,
+                  "destination wrap around");
+    if (t > e || t <= f || (tt != 1 && !lua_compare(L, 1, tt, LUA_OPEQ))) {
+      for (i = 0; i < n; i++) {
+        lua_geti(L, 1, f + i);
+        lua_seti(L, tt, t + i);
+      }
+    }
+    else {
+      for (i = n - 1; i >= 0; i--) {
+        lua_geti(L, 1, f + i);
+        lua_seti(L, tt, t + i);
+      }
+    }
+  }
+  lua_pushvalue(L, tt);  /* return destination table */
+  return 1;
 }
 
 
@@ -306,12 +353,16 @@ static int sort (lua_State *L) {
 
 static const luaL_Reg tab_funcs[] = {
   {"concat", tconcat},
+  {"create", tcreate},
   {"foreach", foreach},
   {"foreachi", foreachi},
   {"getn", getn},
   {"maxn", maxn},
   {"insert", tinsert},
+  {"pack", tpack},
+  {"unpack", tunpack},
   {"remove", tremove},
+  {"move", tmove},
   {"setn", setn},
   {"sort", sort},
   {NULL, NULL}

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -88,10 +88,10 @@ static int setn (lua_State *L) {
 
 
 static int tcreate (lua_State *L) {
-  lua_Unsigned sizeseq = (lua_Unsigned)luaL_checkinteger(L, 1);
-  lua_Unsigned sizerest = (lua_Unsigned)luaL_optinteger(L, 2, 0);
-  luaL_argcheck(L, sizeseq <= cast_uint(INT_MAX), 1, "out of range");
-  luaL_argcheck(L, sizerest <= cast_uint(INT_MAX), 2, "out of range");
+  int sizeseq = (int)luaL_checkinteger(L, 1);
+  int sizerest = (int)luaL_optinteger(L, 2, 0);
+  luaL_argcheck(L, sizeseq <= cast_uint(MAX_INT), 1, "size out of range");
+  luaL_argcheck(L, sizerest <= cast_uint(MAX_INT), 2, "size out of range");
   lua_createtable(L, cast_int(sizeseq), cast_int(sizerest));
   return 1;
 }
@@ -164,10 +164,10 @@ static int tmove (lua_State *L) {
   checktab(L, 1, TAB_R); // TODO: Decide what to do with the checktabs or find a 5.1 equivelant
   checktab(L, tt, TAB_W);
   if (e >= f) {  /* otherwise, nothing to move */
-    luaL_argcheck(L, f > 0 || e < LUA_MAXINTEGER + f, 3,
+    luaL_argcheck(L, f > 0 || e < MAX_INT + f, 3,
                   "too many elements to move");
     int n = e - f + 1;  /* number of elements to move */
-    luaL_argcheck(L, t <= LUA_MAXINTEGER - n + 1, 4,
+    luaL_argcheck(L, t <= MAX_INT - n + 1, 4,
                   "destination wrap around");
     if (t > e || t <= f || (tt != 1 && !lua_compare(L, 1, tt, LUA_OPEQ))) {
       for (int i = 0; i < n; i++) {

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -225,23 +225,6 @@ static int tpack (lua_State *L) {
   return 1;  /* return table */
 }
 
-
-static int tunpack (lua_State *L) {
-  lua_Unsigned n;
-  lua_Integer i = luaL_optinteger(L, 2, 1);
-  lua_Integer e = luaL_opt(L, luaL_checkinteger, 3, luaL_len(L, 1));
-  if (i > e) return 0;  /* empty range */
-  n = l_castS2U(e) - l_castS2U(i);  /* number of elements minus 1 */
-  if (l_unlikely(n >= (unsigned int)INT_MAX  ||
-                 !lua_checkstack(L, (int)(++n))))
-    return luaL_error(L, "too many results to unpack");
-  for (; i < e; i++) {  /* push arg[i..e - 1] (to avoid overflows) */
-    lua_geti(L, 1, i);
-  }
-  lua_geti(L, 1, e);  /* push last element */
-  return (int)n;
-}
-
 /* }====================================================== */
 
 
@@ -370,6 +353,8 @@ static const luaL_Reg tab_funcs[] = {
 
 LUALIB_API int luaopen_table (lua_State *L) {
   luaL_register(L, LUA_TABLIBNAME, tab_funcs);
+  lua_getglobal(L, "unpack");
+  lua_setfield(L, -2, "unpack");
   return 1;
 }
 

--- a/src/ltablib.cpp
+++ b/src/ltablib.cpp
@@ -157,29 +157,28 @@ static void addfield (lua_State *L, luaL_Buffer *b, int i) {
 ** than origin, or copying to another table.
 */
 static int tmove (lua_State *L) {
-  lua_Integer f = luaL_checkinteger(L, 2);
-  lua_Integer e = luaL_checkinteger(L, 3);
-  lua_Integer t = luaL_checkinteger(L, 4);
+  int f = luaL_checkinteger(L, 2);
+  int e = luaL_checkinteger(L, 3);
+  int t = luaL_checkinteger(L, 4);
   int tt = !lua_isnoneornil(L, 5) ? 5 : 1;  /* destination table */
-  checktab(L, 1, TAB_R);
+  checktab(L, 1, TAB_R); // TODO: Decide what to do with the checktabs or find a 5.1 equivelant
   checktab(L, tt, TAB_W);
   if (e >= f) {  /* otherwise, nothing to move */
-    lua_Integer n, i;
     luaL_argcheck(L, f > 0 || e < LUA_MAXINTEGER + f, 3,
                   "too many elements to move");
-    n = e - f + 1;  /* number of elements to move */
+    int n = e - f + 1;  /* number of elements to move */
     luaL_argcheck(L, t <= LUA_MAXINTEGER - n + 1, 4,
                   "destination wrap around");
     if (t > e || t <= f || (tt != 1 && !lua_compare(L, 1, tt, LUA_OPEQ))) {
-      for (i = 0; i < n; i++) {
-        lua_geti(L, 1, f + i);
-        lua_seti(L, tt, t + i);
+      for (int i = 0; i < n; i++) {
+        lua_rawgeti(L, 1, f + i);
+        lua_rawseti(L, tt, t + i);
       }
     }
     else {
-      for (i = n - 1; i >= 0; i--) {
-        lua_geti(L, 1, f + i);
-        lua_seti(L, tt, t + i);
+      for (int i = n - 1; i >= 0; i--) {
+        lua_rawgeti(L, 1, f + i);
+        lua_rawseti(L, tt, t + i);
       }
     }
   }

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -310,6 +310,30 @@ void luaV_concat (lua_State *L, int total, int last) {
 }
 
 
+void luaV_objlen (lua_State *L, StkId ra, const TValue *rb) {
+  const TValue *tm = luaT_gettmbyobj(L, rb, TM_LEN);
+  if (ttisnil(tm)) {  /* no metamethod? */
+    switch (ttype(rb)) {
+      case LUA_TTABLE: {
+        Table *h = hvalue(rb);
+        setnvalue(ra, cast_num(luaH_getn(h)));  /* else primitive len */
+        return;
+      }
+      case LUA_TSTRING: {
+        setnvalue(ra, cast_num(tsvalue(rb)->len));
+        return;
+      }
+      default: {  /* try metamethod */
+        luaG_typeerror(L, rb, "get length of");
+        break;
+      }
+    }
+  } else {
+    callTM(L, tm, rb, rb, ra, 1);
+  };
+}
+
+
 static void Arith (lua_State *L, StkId ra, const TValue *rb,
                    const TValue *rc, TMS op) {
   TValue tempb, tempc;
@@ -511,7 +535,13 @@ void luaV_execute (lua_State *L, int nexeccalls) {
         const TValue *rb = RB(i);
         switch (ttype(rb)) {
           case LUA_TTABLE: {
-            setnvalue(ra, cast_num(luaH_getn(hvalue(rb))));
+            Table *h = hvalue(rb);
+            tm = fasttm(L, h->metatable, TM_LEN);
+            if (tm) {  /* metamethod? break switch to call it */
+              Protect(callTM(L, tm, rb, rb, ra, 1));
+              break;
+            };
+            setnvalue(ra, cast_num(luaH_getn(h)));  /* else primitive len */
             break;
           }
           case LUA_TSTRING: {
@@ -519,10 +549,8 @@ void luaV_execute (lua_State *L, int nexeccalls) {
             break;
           }
           default: {  /* try metamethod */
-            Protect(
-              if (!call_binTM(L, rb, luaO_nilobject, ra, TM_LEN))
-                luaG_typeerror(L, rb, "get length of");
-            )
+            // slow-path, may invoke C/Lua via metamethods
+            Protect(luaV_objlen(L, ra, rb));
           }
         }
         continue;

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -310,30 +310,6 @@ void luaV_concat (lua_State *L, int total, int last) {
 }
 
 
-void luaV_objlen (lua_State *L, StkId ra, const TValue *rb) {
-  const TValue *tm = luaT_gettmbyobj(L, rb, TM_LEN);
-  if (ttisnil(tm)) {  /* no metamethod? */
-    switch (ttype(rb)) {
-      case LUA_TTABLE: {
-        Table *h = hvalue(rb);
-        setnvalue(ra, cast_num(luaH_getn(h)));  /* else primitive len */
-        return;
-      }
-      case LUA_TSTRING: {
-        setnvalue(ra, cast_num(tsvalue(rb)->len));
-        return;
-      }
-      default: {  /* try metamethod */
-        luaG_typeerror(L, rb, "get length of");
-        break;
-      }
-    }
-  } else {
-    callTM(L, tm, rb, rb, ra, 1);
-  };
-}
-
-
 static void Arith (lua_State *L, StkId ra, const TValue *rb,
                    const TValue *rc, TMS op) {
   TValue tempb, tempc;
@@ -550,7 +526,10 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           }
           default: {  /* try metamethod */
             // slow-path, may invoke C/Lua via metamethods
-            Protect(luaV_objlen(L, ra, rb));
+            Protect(
+              if (!call_binTM(L, rb, luaO_nilobject, ra, TM_LEN))
+                luaG_typeerror(L, rb, "get length of");
+            )
           }
         }
         continue;

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -26,6 +26,13 @@
 #include "ltm.h"
 #include "lvm.h"
 
+#if defined(__GNUC__) || defined(__clang__)
+#define VM_USE_DIRECT_THREAD 1
+#else
+#define VM_USE_DIRECT_THREAD 0
+#endif
+// TODO: Decide a better heurestic for directthreading ^^^^^^^^^^^^^^^^
+
 
 
 /* limit for table tag-method chains (to avoid loops) */
@@ -369,12 +376,57 @@ static void Arith (lua_State *L, StkId ra, const TValue *rb,
       }
 
 
+#if VM_USE_DIRECT_THREAD
+/* fetch an instruction and prepare its execution */
+#define vmfetch()       { \
+  if (l_unlikely(trap)) {  /* stack reallocation or hooks? */ \
+    trap = luaG_traceexec(L, pc);  /* handle hooks */ \
+    updatebase(ci);  /* correct stack */ \
+  } \
+  i = *(pc++); \
+}
+
+#define vmdispatch(o)   goto* op_dispatch[o]
+#define vmcase(l)       l:
+#define vmbreak         i = *pc++;ra = RA(i);goto* op_dispatch[GET_OPCODE(i)]
+#define vmopdef(op)     &&op
+// Dreadful re-definition of list of opcodes because C's pre-proessor isn't advanced enough :/
+#define vmopdispatchlist() /
+  vmopdef(OP_MOVE), vmopdef(OP_LOADK), vmopdef(OP_LOADBOOL), vmopdef(OP_LOADNIL), \
+  vmopdef(OP_GETUPVAL), vmopdef(OP_GETGLOBAL), vmopdef(OP_GETTABLE), vmopdef(OP_SETGLOBAL), \
+  vmopdef(OP_SETUPVAL), vmopdef(OP_SETTABLE), vmopdef(OP_NEWTABLE), vmopdef(OP_SELF), \
+  vmopdef(OP_ADD), vmopdef(OP_SUB), vmopdef(OP_MUL), vmopdef(OP_DIV), \
+  vmopdef(OP_MOD), vmopdef(OP_POW), vmopdef(OP_UNM), vmopdef(OP_NOT), \
+  vmopdef(OP_LEN), vmopdef(OP_CONCAT), vmopdef(OP_JMP), vmopdef(OP_EQ), \
+  vmopdef(OP_LT), vmopdef(OP_LE), vmopdef(OP_TEST), vmopdef(OP_TESTSET), \
+  vmopdef(OP_CALL), vmopdef(OP_TAILCALL), vmopdef(OP_RETURN), vmopdef(OP_FORLOOP), \
+  vmopdef(OP_FORPREP), vmopdef(OP_TFORLOOP), vmopdef(OP_SETLIST), vmopdef(OP_CLOSE), \
+  vmopdef(OP_CLOSURE), vmopdef(OP_VARARG)
+#else
+/* fetch an instruction and prepare its execution */
+#define vmfetch()       { \
+  if (l_unlikely(trap)) {  /* stack reallocation or hooks? */ \
+    trap = luaG_traceexec(L, pc);  /* handle hooks */ \
+    updatebase(ci);  /* correct stack */ \
+  } \
+  i = *(pc++); \
+}
+
+#define vmdispatch(o)   switch(o)
+#define vmcase(l)       case l:
+#define vmbreak         continue
+#endif
+
+
 
 void luaV_execute (lua_State *L, int nexeccalls) {
   LClosure *cl;
   StkId base;
   TValue *k;
   const Instruction *pc;
+  #if VM_USE_DIRECT_THREAD
+    static const void* op_dispatch[256] = [vmopdispatchlist()];
+  #endif
  reentry:  /* entry point */
   lua_assert(isLua(L->ci));
   pc = L->savedpc;
@@ -383,7 +435,11 @@ void luaV_execute (lua_State *L, int nexeccalls) {
   k = cl->p->k;
   /* main loop of interpreter */
   for (;;) {
-    const Instruction i = *pc++;
+    #if VM_USE_DIRECT_THREAD
+      Instruction i = *pc++;
+    #else
+      const Instruction i = *pc++;
+    #endif
     StkId ra;
     if ((L->hookmask & (LUA_MASKLINE | LUA_MASKCOUNT)) &&
         (--L->hookcount == 0 || L->hookmask & LUA_MASKLINE)) {
@@ -399,99 +455,99 @@ void luaV_execute (lua_State *L, int nexeccalls) {
     lua_assert(base == L->base && L->base == L->ci->base);
     lua_assert(base <= L->top && L->top <= L->stack + L->stacksize);
     lua_assert(L->top == L->ci->top || luaG_checkopenop(i));
-    switch (GET_OPCODE(i)) {
-      case OP_MOVE: {
+    vmdispatch (GET_OPCODE(i)) {
+      vmcase(OP_MOVE) {
         setobjs2s(L, ra, RB(i));
-        continue;
+        vmbreak;
       }
-      case OP_LOADK: {
+      vmcase(OP_LOADK) {
         setobj2s(L, ra, KBx(i));
-        continue;
+        vmbreak;
       }
-      case OP_LOADBOOL: {
+      vmcase(OP_LOADBOOL) {
         setbvalue(ra, GETARG_B(i));
         if (GETARG_C(i)) pc++;  /* skip next instruction (if C) */
-        continue;
+        vmbreak;
       }
-      case OP_LOADNIL: {
+      vmcase(OP_LOADNIL) {
         TValue *rb = RB(i);
         do {
           setnilvalue(rb--);
         } while (rb >= ra);
-        continue;
+        vmbreak;
       }
-      case OP_GETUPVAL: {
+      vmcase(OP_GETUPVAL) {
         int b = GETARG_B(i);
         setobj2s(L, ra, cl->upvals[b]->v);
-        continue;
+        vmbreak;
       }
-      case OP_GETGLOBAL: {
+      vmcase(OP_GETGLOBAL) {
         TValue g;
         TValue *rb = KBx(i);
         sethvalue(L, &g, cl->env);
         lua_assert(ttisstring(rb));
         Protect(luaV_gettable(L, &g, rb, ra));
-        continue;
+        vmbreak;
       }
-      case OP_GETTABLE: {
+      vmcase(OP_GETTABLE) {
         Protect(luaV_gettable(L, RB(i), RKC(i), ra));
-        continue;
+        vmbreak;
       }
-      case OP_SETGLOBAL: {
+      vmcase(OP_SETGLOBAL) {
         TValue g;
         sethvalue(L, &g, cl->env);
         lua_assert(ttisstring(KBx(i)));
         Protect(luaV_settable(L, &g, KBx(i), ra));
-        continue;
+        vmbreak;
       }
-      case OP_SETUPVAL: {
+      vmcase(OP_SETUPVAL) {
         UpVal *uv = cl->upvals[GETARG_B(i)];
         setobj(L, uv->v, ra);
         luaC_barrier(L, uv, ra);
-        continue;
+        vmbreak;
       }
-      case OP_SETTABLE: {
+      vmcase(OP_SETTABLE) {
         Protect(luaV_settable(L, ra, RKB(i), RKC(i)));
-        continue;
+        vmbreak;
       }
-      case OP_NEWTABLE: {
+      vmcase(OP_NEWTABLE) {
         int b = GETARG_B(i);
         int c = GETARG_C(i);
         sethvalue(L, ra, luaH_new(L, luaO_fb2int(b), luaO_fb2int(c)));
         Protect(luaC_checkGC(L));
-        continue;
+        vmbreak;
       }
-      case OP_SELF: {
+      vmcase(OP_SELF) {
         StkId rb = RB(i);
         setobjs2s(L, ra+1, rb);
         Protect(luaV_gettable(L, rb, RKC(i), ra));
-        continue;
+        vmbreak;
       }
-      case OP_ADD: {
+      vmcase(OP_ADD) {
         arith_op(luai_numadd, TM_ADD);
-        continue;
+        vmbreak;
       }
-      case OP_SUB: {
+      vmcase(OP_SUB) {
         arith_op(luai_numsub, TM_SUB);
-        continue;
+        vmbreak;
       }
-      case OP_MUL: {
+      vmcase(OP_MUL) {
         arith_op(luai_nummul, TM_MUL);
-        continue;
+        vmbreak;
       }
-      case OP_DIV: {
+      vmcase(OP_DIV) {
         arith_op(luai_numdiv, TM_DIV);
-        continue;
+        vmbreak;
       }
-      case OP_MOD: {
+      vmcase(OP_MOD) {
         arith_op(luai_nummod, TM_MOD);
-        continue;
+        vmbreak;
       }
-      case OP_POW: {
+      vmcase(OP_POW) {
         arith_op(luai_numpow, TM_POW);
-        continue;
+        vmbreak;
       }
-      case OP_UNM: {
+      vmcase(OP_UNM) {
         TValue *rb = RB(i);
         if (ttisnumber(rb)) {
           lua_Number nb = nvalue(rb);
@@ -500,14 +556,14 @@ void luaV_execute (lua_State *L, int nexeccalls) {
         else {
           Protect(Arith(L, ra, rb, rb, TM_UNM));
         }
-        continue;
+        vmbreak;
       }
-      case OP_NOT: {
+      vmcase(OP_NOT) {
         int res = l_isfalse(RB(i));  /* next assignment may change this value */
         setbvalue(ra, res);
-        continue;
+        vmbreak;
       }
-      case OP_LEN: {
+      vmcase(OP_LEN) {
         const TValue *rb = RB(i);
         switch (ttype(rb)) {
           case LUA_TTABLE: {
@@ -532,20 +588,20 @@ void luaV_execute (lua_State *L, int nexeccalls) {
             )
           }
         }
-        continue;
+        vmbreak;
       }
-      case OP_CONCAT: {
+      vmcase(OP_CONCAT) {
         int b = GETARG_B(i);
         int c = GETARG_C(i);
         Protect(luaV_concat(L, c-b+1, c); luaC_checkGC(L));
         setobjs2s(L, RA(i), base+b);
-        continue;
+        vmbreak;
       }
-      case OP_JMP: {
+      vmcase(OP_JMP) {
         dojump(L, pc, GETARG_sBx(i));
-        continue;
+        vmbreak;
       }
-      case OP_EQ: {
+      vmcase(OP_EQ) {
         TValue *rb = RKB(i);
         TValue *rc = RKC(i);
         Protect(
@@ -553,40 +609,40 @@ void luaV_execute (lua_State *L, int nexeccalls) {
             dojump(L, pc, GETARG_sBx(*pc));
         )
         pc++;
-        continue;
+        vmbreak;
       }
-      case OP_LT: {
+      vmcase(OP_LT) {
         Protect(
           if (luaV_lessthan(L, RKB(i), RKC(i)) == GETARG_A(i))
             dojump(L, pc, GETARG_sBx(*pc));
         )
         pc++;
-        continue;
+        vmbreak;
       }
-      case OP_LE: {
+      vmcase(OP_LE) {
         Protect(
           if (lessequal(L, RKB(i), RKC(i)) == GETARG_A(i))
             dojump(L, pc, GETARG_sBx(*pc));
         )
         pc++;
-        continue;
+        vmbreak;
       }
-      case OP_TEST: {
+      vmcase(OP_TEST) {
         if (l_isfalse(ra) != GETARG_C(i))
           dojump(L, pc, GETARG_sBx(*pc));
         pc++;
-        continue;
+        vmbreak;
       }
-      case OP_TESTSET: {
+      vmcase(OP_TESTSET) {
         TValue *rb = RB(i);
         if (l_isfalse(rb) != GETARG_C(i)) {
           setobjs2s(L, ra, rb);
           dojump(L, pc, GETARG_sBx(*pc));
         }
         pc++;
-        continue;
+        vmbreak;
       }
-      case OP_CALL: {
+      vmcase(OP_CALL) {
         int b = GETARG_B(i);
         int nresults = GETARG_C(i) - 1;
         if (b != 0) L->top = ra+b;  /* else previous instruction set top */
@@ -600,14 +656,14 @@ void luaV_execute (lua_State *L, int nexeccalls) {
             /* it was a C function (`precall' called it); adjust results */
             if (nresults >= 0) L->top = L->ci->top;
             base = L->base;
-            continue;
+            vmbreak;
           }
           default: {
             return;  /* yield */
           }
         }
       }
-      case OP_TAILCALL: {
+      vmcase(OP_TAILCALL) {
         int b = GETARG_B(i);
         if (b != 0) L->top = ra+b;  /* else previous instruction set top */
         L->savedpc = pc;
@@ -632,14 +688,14 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           }
           case PCRC: {  /* it was a C function (`precall' called it) */
             base = L->base;
-            continue;
+            vmbreak;
           }
           default: {
             return;  /* yield */
           }
         }
       }
-      case OP_RETURN: {
+      vmcase(OP_RETURN) {
         int b = GETARG_B(i);
         if (b != 0) L->top = ra+b-1;
         if (L->openupval) luaF_close(L, base);
@@ -654,7 +710,7 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           goto reentry;
         }
       }
-      case OP_FORLOOP: {
+      vmcase(OP_FORLOOP) {
         lua_Number step = nvalue(ra+2);
         lua_Number idx = luai_numadd(nvalue(ra), step); /* increment index */
         lua_Number limit = nvalue(ra+1);
@@ -664,9 +720,9 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           setnvalue(ra, idx);  /* update internal index... */
           setnvalue(ra+3, idx);  /* ...and external index */
         }
-        continue;
+        vmbreak;
       }
-      case OP_FORPREP: {
+      vmcase(OP_FORPREP) {
         const TValue *init = ra;
         const TValue *plimit = ra+1;
         const TValue *pstep = ra+2;
@@ -679,9 +735,9 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           luaG_runerror(L, LUA_QL("for") " step must be a number");
         setnvalue(ra, luai_numsub(nvalue(ra), nvalue(pstep)));
         dojump(L, pc, GETARG_sBx(i));
-        continue;
+        vmbreak;
       }
-      case OP_TFORLOOP: {
+      vmcase(OP_TFORLOOP) {
         StkId cb = ra + 3;  /* call base */
         setobjs2s(L, cb+2, ra+2);
         setobjs2s(L, cb+1, ra+1);
@@ -695,9 +751,9 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           dojump(L, pc, GETARG_sBx(*pc));  /* jump back */
         }
         pc++;
-        continue;
+        vmbreak;
       }
-      case OP_SETLIST: {
+      vmcase(OP_SETLIST) {
         int n = GETARG_B(i);
         int c = GETARG_C(i);
         int last;
@@ -717,13 +773,13 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           setobj2t(L, luaH_setnum(L, h, last--), val);
           luaC_barriert(L, h, val);
         }
-        continue;
+        vmbreak;
       }
-      case OP_CLOSE: {
+      vmcase(OP_CLOSE) {
         luaF_close(L, ra);
-        continue;
+        vmbreak;
       }
-      case OP_CLOSURE: {
+      vmcase(OP_CLOSURE) {
         Proto *p;
         Closure *ncl;
         int nup, j;
@@ -741,9 +797,9 @@ void luaV_execute (lua_State *L, int nexeccalls) {
         }
         setclvalue(L, ra, ncl);
         Protect(luaC_checkGC(L));
-        continue;
+        vmbreak;
       }
-      case OP_VARARG: {
+      vmcase(OP_VARARG) {
         int b = GETARG_B(i) - 1;
         int j;
         CallInfo *ci = L->ci;
@@ -762,7 +818,7 @@ void luaV_execute (lua_State *L, int nexeccalls) {
             setnilvalue(ra + j);
           }
         }
-        continue;
+        vmbreak;
       }
     }
   }

--- a/src/lvm.cpp
+++ b/src/lvm.cpp
@@ -26,13 +26,6 @@
 #include "ltm.h"
 #include "lvm.h"
 
-#if defined(__GNUC__) || defined(__clang__)
-#define VM_USE_DIRECT_THREAD 1
-#else
-#define VM_USE_DIRECT_THREAD 0
-#endif
-// TODO: Decide a better heurestic for directthreading ^^^^^^^^^^^^^^^^
-
 
 
 /* limit for table tag-method chains (to avoid loops) */
@@ -376,57 +369,12 @@ static void Arith (lua_State *L, StkId ra, const TValue *rb,
       }
 
 
-#if VM_USE_DIRECT_THREAD
-/* fetch an instruction and prepare its execution */
-#define vmfetch()       { \
-  if (l_unlikely(trap)) {  /* stack reallocation or hooks? */ \
-    trap = luaG_traceexec(L, pc);  /* handle hooks */ \
-    updatebase(ci);  /* correct stack */ \
-  } \
-  i = *(pc++); \
-}
-
-#define vmdispatch(o)   goto* op_dispatch[o]
-#define vmcase(l)       l:
-#define vmbreak         i = *pc++;ra = RA(i);goto* op_dispatch[GET_OPCODE(i)]
-#define vmopdef(op)     &&op
-// Dreadful re-definition of list of opcodes because C's pre-proessor isn't advanced enough :/
-#define vmopdispatchlist() /
-  vmopdef(OP_MOVE), vmopdef(OP_LOADK), vmopdef(OP_LOADBOOL), vmopdef(OP_LOADNIL), \
-  vmopdef(OP_GETUPVAL), vmopdef(OP_GETGLOBAL), vmopdef(OP_GETTABLE), vmopdef(OP_SETGLOBAL), \
-  vmopdef(OP_SETUPVAL), vmopdef(OP_SETTABLE), vmopdef(OP_NEWTABLE), vmopdef(OP_SELF), \
-  vmopdef(OP_ADD), vmopdef(OP_SUB), vmopdef(OP_MUL), vmopdef(OP_DIV), \
-  vmopdef(OP_MOD), vmopdef(OP_POW), vmopdef(OP_UNM), vmopdef(OP_NOT), \
-  vmopdef(OP_LEN), vmopdef(OP_CONCAT), vmopdef(OP_JMP), vmopdef(OP_EQ), \
-  vmopdef(OP_LT), vmopdef(OP_LE), vmopdef(OP_TEST), vmopdef(OP_TESTSET), \
-  vmopdef(OP_CALL), vmopdef(OP_TAILCALL), vmopdef(OP_RETURN), vmopdef(OP_FORLOOP), \
-  vmopdef(OP_FORPREP), vmopdef(OP_TFORLOOP), vmopdef(OP_SETLIST), vmopdef(OP_CLOSE), \
-  vmopdef(OP_CLOSURE), vmopdef(OP_VARARG)
-#else
-/* fetch an instruction and prepare its execution */
-#define vmfetch()       { \
-  if (l_unlikely(trap)) {  /* stack reallocation or hooks? */ \
-    trap = luaG_traceexec(L, pc);  /* handle hooks */ \
-    updatebase(ci);  /* correct stack */ \
-  } \
-  i = *(pc++); \
-}
-
-#define vmdispatch(o)   switch(o)
-#define vmcase(l)       case l:
-#define vmbreak         continue
-#endif
-
-
 
 void luaV_execute (lua_State *L, int nexeccalls) {
   LClosure *cl;
   StkId base;
   TValue *k;
   const Instruction *pc;
-  #if VM_USE_DIRECT_THREAD
-    static const void* op_dispatch[256] = [vmopdispatchlist()];
-  #endif
  reentry:  /* entry point */
   lua_assert(isLua(L->ci));
   pc = L->savedpc;
@@ -435,11 +383,7 @@ void luaV_execute (lua_State *L, int nexeccalls) {
   k = cl->p->k;
   /* main loop of interpreter */
   for (;;) {
-    #if VM_USE_DIRECT_THREAD
-      Instruction i = *pc++;
-    #else
-      const Instruction i = *pc++;
-    #endif
+    const Instruction i = *pc++;
     StkId ra;
     if ((L->hookmask & (LUA_MASKLINE | LUA_MASKCOUNT)) &&
         (--L->hookcount == 0 || L->hookmask & LUA_MASKLINE)) {
@@ -455,99 +399,99 @@ void luaV_execute (lua_State *L, int nexeccalls) {
     lua_assert(base == L->base && L->base == L->ci->base);
     lua_assert(base <= L->top && L->top <= L->stack + L->stacksize);
     lua_assert(L->top == L->ci->top || luaG_checkopenop(i));
-    vmdispatch (GET_OPCODE(i)) {
-      vmcase(OP_MOVE) {
+    switch (GET_OPCODE(i)) {
+      case OP_MOVE: {
         setobjs2s(L, ra, RB(i));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_LOADK) {
+      case OP_LOADK: {
         setobj2s(L, ra, KBx(i));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_LOADBOOL) {
+      case OP_LOADBOOL: {
         setbvalue(ra, GETARG_B(i));
         if (GETARG_C(i)) pc++;  /* skip next instruction (if C) */
-        vmbreak;
+        continue;
       }
-      vmcase(OP_LOADNIL) {
+      case OP_LOADNIL: {
         TValue *rb = RB(i);
         do {
           setnilvalue(rb--);
         } while (rb >= ra);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_GETUPVAL) {
+      case OP_GETUPVAL: {
         int b = GETARG_B(i);
         setobj2s(L, ra, cl->upvals[b]->v);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_GETGLOBAL) {
+      case OP_GETGLOBAL: {
         TValue g;
         TValue *rb = KBx(i);
         sethvalue(L, &g, cl->env);
         lua_assert(ttisstring(rb));
         Protect(luaV_gettable(L, &g, rb, ra));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_GETTABLE) {
+      case OP_GETTABLE: {
         Protect(luaV_gettable(L, RB(i), RKC(i), ra));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_SETGLOBAL) {
+      case OP_SETGLOBAL: {
         TValue g;
         sethvalue(L, &g, cl->env);
         lua_assert(ttisstring(KBx(i)));
         Protect(luaV_settable(L, &g, KBx(i), ra));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_SETUPVAL) {
+      case OP_SETUPVAL: {
         UpVal *uv = cl->upvals[GETARG_B(i)];
         setobj(L, uv->v, ra);
         luaC_barrier(L, uv, ra);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_SETTABLE) {
+      case OP_SETTABLE: {
         Protect(luaV_settable(L, ra, RKB(i), RKC(i)));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_NEWTABLE) {
+      case OP_NEWTABLE: {
         int b = GETARG_B(i);
         int c = GETARG_C(i);
         sethvalue(L, ra, luaH_new(L, luaO_fb2int(b), luaO_fb2int(c)));
         Protect(luaC_checkGC(L));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_SELF) {
+      case OP_SELF: {
         StkId rb = RB(i);
         setobjs2s(L, ra+1, rb);
         Protect(luaV_gettable(L, rb, RKC(i), ra));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_ADD) {
+      case OP_ADD: {
         arith_op(luai_numadd, TM_ADD);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_SUB) {
+      case OP_SUB: {
         arith_op(luai_numsub, TM_SUB);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_MUL) {
+      case OP_MUL: {
         arith_op(luai_nummul, TM_MUL);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_DIV) {
+      case OP_DIV: {
         arith_op(luai_numdiv, TM_DIV);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_MOD) {
+      case OP_MOD: {
         arith_op(luai_nummod, TM_MOD);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_POW) {
+      case OP_POW: {
         arith_op(luai_numpow, TM_POW);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_UNM) {
+      case OP_UNM: {
         TValue *rb = RB(i);
         if (ttisnumber(rb)) {
           lua_Number nb = nvalue(rb);
@@ -556,14 +500,14 @@ void luaV_execute (lua_State *L, int nexeccalls) {
         else {
           Protect(Arith(L, ra, rb, rb, TM_UNM));
         }
-        vmbreak;
+        continue;
       }
-      vmcase(OP_NOT) {
+      case OP_NOT: {
         int res = l_isfalse(RB(i));  /* next assignment may change this value */
         setbvalue(ra, res);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_LEN) {
+      case OP_LEN: {
         const TValue *rb = RB(i);
         switch (ttype(rb)) {
           case LUA_TTABLE: {
@@ -588,20 +532,20 @@ void luaV_execute (lua_State *L, int nexeccalls) {
             )
           }
         }
-        vmbreak;
+        continue;
       }
-      vmcase(OP_CONCAT) {
+      case OP_CONCAT: {
         int b = GETARG_B(i);
         int c = GETARG_C(i);
         Protect(luaV_concat(L, c-b+1, c); luaC_checkGC(L));
         setobjs2s(L, RA(i), base+b);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_JMP) {
+      case OP_JMP: {
         dojump(L, pc, GETARG_sBx(i));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_EQ) {
+      case OP_EQ: {
         TValue *rb = RKB(i);
         TValue *rc = RKC(i);
         Protect(
@@ -609,40 +553,40 @@ void luaV_execute (lua_State *L, int nexeccalls) {
             dojump(L, pc, GETARG_sBx(*pc));
         )
         pc++;
-        vmbreak;
+        continue;
       }
-      vmcase(OP_LT) {
+      case OP_LT: {
         Protect(
           if (luaV_lessthan(L, RKB(i), RKC(i)) == GETARG_A(i))
             dojump(L, pc, GETARG_sBx(*pc));
         )
         pc++;
-        vmbreak;
+        continue;
       }
-      vmcase(OP_LE) {
+      case OP_LE: {
         Protect(
           if (lessequal(L, RKB(i), RKC(i)) == GETARG_A(i))
             dojump(L, pc, GETARG_sBx(*pc));
         )
         pc++;
-        vmbreak;
+        continue;
       }
-      vmcase(OP_TEST) {
+      case OP_TEST: {
         if (l_isfalse(ra) != GETARG_C(i))
           dojump(L, pc, GETARG_sBx(*pc));
         pc++;
-        vmbreak;
+        continue;
       }
-      vmcase(OP_TESTSET) {
+      case OP_TESTSET: {
         TValue *rb = RB(i);
         if (l_isfalse(rb) != GETARG_C(i)) {
           setobjs2s(L, ra, rb);
           dojump(L, pc, GETARG_sBx(*pc));
         }
         pc++;
-        vmbreak;
+        continue;
       }
-      vmcase(OP_CALL) {
+      case OP_CALL: {
         int b = GETARG_B(i);
         int nresults = GETARG_C(i) - 1;
         if (b != 0) L->top = ra+b;  /* else previous instruction set top */
@@ -656,14 +600,14 @@ void luaV_execute (lua_State *L, int nexeccalls) {
             /* it was a C function (`precall' called it); adjust results */
             if (nresults >= 0) L->top = L->ci->top;
             base = L->base;
-            vmbreak;
+            continue;
           }
           default: {
             return;  /* yield */
           }
         }
       }
-      vmcase(OP_TAILCALL) {
+      case OP_TAILCALL: {
         int b = GETARG_B(i);
         if (b != 0) L->top = ra+b;  /* else previous instruction set top */
         L->savedpc = pc;
@@ -688,14 +632,14 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           }
           case PCRC: {  /* it was a C function (`precall' called it) */
             base = L->base;
-            vmbreak;
+            continue;
           }
           default: {
             return;  /* yield */
           }
         }
       }
-      vmcase(OP_RETURN) {
+      case OP_RETURN: {
         int b = GETARG_B(i);
         if (b != 0) L->top = ra+b-1;
         if (L->openupval) luaF_close(L, base);
@@ -710,7 +654,7 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           goto reentry;
         }
       }
-      vmcase(OP_FORLOOP) {
+      case OP_FORLOOP: {
         lua_Number step = nvalue(ra+2);
         lua_Number idx = luai_numadd(nvalue(ra), step); /* increment index */
         lua_Number limit = nvalue(ra+1);
@@ -720,9 +664,9 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           setnvalue(ra, idx);  /* update internal index... */
           setnvalue(ra+3, idx);  /* ...and external index */
         }
-        vmbreak;
+        continue;
       }
-      vmcase(OP_FORPREP) {
+      case OP_FORPREP: {
         const TValue *init = ra;
         const TValue *plimit = ra+1;
         const TValue *pstep = ra+2;
@@ -735,9 +679,9 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           luaG_runerror(L, LUA_QL("for") " step must be a number");
         setnvalue(ra, luai_numsub(nvalue(ra), nvalue(pstep)));
         dojump(L, pc, GETARG_sBx(i));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_TFORLOOP) {
+      case OP_TFORLOOP: {
         StkId cb = ra + 3;  /* call base */
         setobjs2s(L, cb+2, ra+2);
         setobjs2s(L, cb+1, ra+1);
@@ -751,9 +695,9 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           dojump(L, pc, GETARG_sBx(*pc));  /* jump back */
         }
         pc++;
-        vmbreak;
+        continue;
       }
-      vmcase(OP_SETLIST) {
+      case OP_SETLIST: {
         int n = GETARG_B(i);
         int c = GETARG_C(i);
         int last;
@@ -773,13 +717,13 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           setobj2t(L, luaH_setnum(L, h, last--), val);
           luaC_barriert(L, h, val);
         }
-        vmbreak;
+        continue;
       }
-      vmcase(OP_CLOSE) {
+      case OP_CLOSE: {
         luaF_close(L, ra);
-        vmbreak;
+        continue;
       }
-      vmcase(OP_CLOSURE) {
+      case OP_CLOSURE: {
         Proto *p;
         Closure *ncl;
         int nup, j;
@@ -797,9 +741,9 @@ void luaV_execute (lua_State *L, int nexeccalls) {
         }
         setclvalue(L, ra, ncl);
         Protect(luaC_checkGC(L));
-        vmbreak;
+        continue;
       }
-      vmcase(OP_VARARG) {
+      case OP_VARARG: {
         int b = GETARG_B(i) - 1;
         int j;
         CallInfo *ci = L->ci;
@@ -818,7 +762,7 @@ void luaV_execute (lua_State *L, int nexeccalls) {
             setnilvalue(ra + j);
           }
         }
-        vmbreak;
+        continue;
       }
     }
   }


### PR DESCRIPTION
Fixes: https://github.com/cuberite/cuberite/issues/5472

This adds:
- [x] `table.pack`
- [x] `table.unpack`
- [x] `table.move`
- [x] `table.create`
- [x] `rawlen`
- [x] `coroutine.isyieldable`
- [x] tables honor the `__len` metamethod
- [x] optional base in `math.log` ???
- [x] arguments for function called through `xpcall`
- [x] optional separator in `string.rep` ???
- [x] optional `init` argument to `string.gmatch` ???

TODO:
- [x] Fully implement coroutine.isyieldable
- [ ] Implement other stuff??
- [ ] Test that everything works properly

